### PR TITLE
disambiguate conflict when package GeneSet is also loaded

### DIFF
--- a/R/xCellData.R
+++ b/R/xCellData.R
@@ -12,5 +12,5 @@
 #' xCellData()
 xCellData <- function() {
     gmtFile <- system.file(package = "xCellData", 'extdata', "xCell.gmt")
-    import.gmt(gmtFile)
+    unisets::import.gmt(gmtFile)
 }


### PR DESCRIPTION
`Kayla-Morrell/GeneSet` and `kevinrue/unisets` both define `import.gmt`, the last package loaded was winning. This makes sure the `unisets` function is called and a `BaseSets` is returned